### PR TITLE
Added thehive3.4/3.5-cortex-nginx examples

### DIFF
--- a/docker/thehive34-cortex3-es6-nginx-https/.env
+++ b/docker/thehive34-cortex3-es6-nginx-https/.env
@@ -1,0 +1,2 @@
+# Cortex configuration
+CORTEX_KEY=[API KEY OF CORTEX USER]

--- a/docker/thehive34-cortex3-es6-nginx-https/README.md
+++ b/docker/thehive34-cortex3-es6-nginx-https/README.md
@@ -1,0 +1,40 @@
+# thehive34-cortex3-es6-nginx-https
+
+:warning: Elasticsearch 6 is deprecated and TheHive 3.4.x is no longer maintained.  Consider using TheHive 3.5+ with Elasticsearch 7.
+
+This is a docker-compose configuration to run a TheHive 3.4.4 + Cortex 3.0.1 instance with an Elasticsearch 6.8.8 database backend.  Nginx 1.19.5 is used as reverse proxy in which you supply your own ssl certificates.
+
+Elasticsearch storage has not been configured as persistent in this docker-compose file.
+
+## .env File
+
+Populate the .env with the following entries.  
+
+| variable              | entry                                         |
+|-----------------------|-----------------------------------------------|
+| CORTEX_KEY            | API KEY OF CORTEX USER - POPULATED POST SETUP |
+
+NOTE: You need to configure Cortex to generate the required API KEY.  Once you have created the API KEY you need to rerun `docker-compose up -d`.
+
+## Usage
+
+```bash
+docker-compose up -d
+```
+
+## Volume Configuration
+
+- Local files stored in `./vol/nginx` are mapped to the container under `/etc/nginx/conf.d`.  
+- Local files stored in `./vol/ssl` are mapped to the container under `/etc/ssl`.  
+
+## TODO
+
+The following items require your attention:
+
+- [ ] Update `thehive.conf` and `cortex.conf` files as appropriate
+  - [ ] Update `server_name` for your fqdn
+  - [ ] Review/modify the configuration for your requirements
+- [ ] Add your certificates to `./vol/ssl`
+- [ ] Update `./vol/nginx/certs.conf` with the certificate file names
+- [ ] Update `.env` with the `CORTEX_KEY` after Cortex has been setup and configured
+- [ ] Add persistent storage for Elasticsearch

--- a/docker/thehive34-cortex3-es6-nginx-https/docker-compose.yml
+++ b/docker/thehive34-cortex3-es6-nginx-https/docker-compose.yml
@@ -1,0 +1,58 @@
+version: '3'
+
+services:
+  nginx:
+    container_name: nginx
+    hostname: nginx
+    image: nginx:1.19.5
+    ports:
+      - 80:80
+      - 443:443
+    networks:
+      - proxy
+    volumes:
+      - ./vol/nginx:/etc/nginx/conf.d
+      - ./vol/ssl:/etc/ssl
+    restart: on-failure
+
+  elasticsearch:
+    container_name: elasticsearch
+    image: 'elasticsearch:6.8.8'
+    environment:
+      - http.host=0.0.0.0
+      - discovery.type=single-node
+      - script.allowed_types=inline
+      - thread_pool.search.queue_size=100000
+      - thread_pool.write.queue_size=10000
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
+    networks:
+      - backend
+
+  thehive:
+    container_name: thehive
+    image: thehiveproject/thehive:3.4.4-1
+    depends_on:
+      - elasticsearch
+    networks:
+      - proxy
+      - backend
+    command:
+      --cortex-port 9001
+      --cortex-key ${CORTEX_KEY}
+      --es-uri http://elasticsearch:9200
+
+  cortex:
+    image: thehiveproject/cortex:3.0.1
+    depends_on:
+      - elasticsearch
+    networks:
+      - proxy
+      - backend
+
+networks:
+  backend:
+  proxy:
+    external: true

--- a/docker/thehive34-cortex3-es6-nginx-https/vol/nginx/certs.conf
+++ b/docker/thehive34-cortex3-es6-nginx-https/vol/nginx/certs.conf
@@ -1,0 +1,2 @@
+ssl_certificate /etc/ssl/nginx-selfsigned.crt;
+ssl_certificate_key /etc/ssl/nginx-selfsigned.key;

--- a/docker/thehive34-cortex3-es6-nginx-https/vol/nginx/cortex.conf
+++ b/docker/thehive34-cortex3-es6-nginx-https/vol/nginx/cortex.conf
@@ -1,0 +1,18 @@
+server {
+  listen 443 ssl;
+  server_name cortex.yourdomain.com;
+
+  proxy_connect_timeout   600;
+  proxy_send_timeout      600;
+  proxy_read_timeout      600;
+  send_timeout            600;
+  client_max_body_size    2G;
+  proxy_buffering off;
+  client_header_buffer_size 8k;
+
+  location / {
+    add_header              Strict-Transport-Security "max-age=31536000; includeSubDomains";
+    proxy_pass            http://cortex:9001;
+    proxy_http_version      1.1;
+  }
+}

--- a/docker/thehive34-cortex3-es6-nginx-https/vol/nginx/thehive.conf
+++ b/docker/thehive34-cortex3-es6-nginx-https/vol/nginx/thehive.conf
@@ -1,0 +1,18 @@
+server {
+  listen 443 ssl;
+  server_name thehive.yourdomain.com;
+
+  proxy_connect_timeout   600;
+  proxy_send_timeout      600;
+  proxy_read_timeout      600;
+  send_timeout            600;
+  client_max_body_size    2G;
+  proxy_buffering off;
+  client_header_buffer_size 8k;
+
+  location / {
+    add_header              Strict-Transport-Security "max-age=31536000; includeSubDomains";
+    proxy_pass            http://thehive:9000;
+    proxy_http_version      1.1;
+  }
+}

--- a/docker/thehive34-cortex3-es6-nginx-https/vol/ssl/README.md
+++ b/docker/thehive34-cortex3-es6-nginx-https/vol/ssl/README.md
@@ -1,0 +1,3 @@
+# README
+
+You need to create and add your certificates into this folder and update the `certs.conf` file.

--- a/docker/thehive35-cortex3-es7-nginx-https/.env
+++ b/docker/thehive35-cortex3-es7-nginx-https/.env
@@ -1,0 +1,3 @@
+# Cortex configuration
+CORTEX_KEY=[API KEY OF CORTEX USER]
+JOB_DIRECTORY=/opt/cortex/jobs

--- a/docker/thehive35-cortex3-es7-nginx-https/README.md
+++ b/docker/thehive35-cortex3-es7-nginx-https/README.md
@@ -1,0 +1,39 @@
+# thehive35-cortex3-es7-nginx-https
+
+This is a docker-compose configuration to run a TheHive 3.5.0-1 + Cortex 3.1.0-1 instance with an Elasticsearch 7.8.1 database backend.  Nginx 1.19.5 is used as reverse proxy in which you supply your own ssl certificates.
+
+Elasticsearch storage has not been configured as persistent in this docker-compose file.
+
+## .env File
+
+Populate the .env with the following entries.  
+
+| variable              | entry                                         |
+|-----------------------|-----------------------------------------------|
+| CORTEX_KEY            | API KEY OF CORTEX USER - POPULATED POST SETUP |
+| JOB_DIRECTORY         | DIRECTORY TO STORE JOB FILES                  |
+
+NOTE: You need to configure Cortex to generate the required API KEY.  Once you have created the API KEY you need to rerun `docker-compose up -d thehive`.
+
+## Usage
+
+```bash
+docker-compose up -d
+```
+
+## Volume Configuration
+
+- Local files stored in `./vol/nginx` are mapped to the container under `/etc/nginx/conf.d`.  
+- Local files stored in `./vol/ssl` are mapped to the container under `/etc/ssl`.  
+
+## TODO
+
+The following items require your attention:
+
+- [ ] Update `thehive.conf` and `cortex.conf` files as appropriate
+  - [ ] Update `server_name` for your fqdn
+  - [ ] Review/modify the configuration for your requirements
+- [ ] Add your certificates to `./vol/ssl`
+- [ ] Update `./vol/nginx/certs.conf` with the certificate file names
+- [ ] Update `.env` with the `CORTEX_KEY` after Cortex has been setup and configured
+- [ ] Add persistent storage for Elasticsearch

--- a/docker/thehive35-cortex3-es7-nginx-https/docker-compose.yml
+++ b/docker/thehive35-cortex3-es7-nginx-https/docker-compose.yml
@@ -1,0 +1,66 @@
+version: '3'
+
+services:
+  nginx:
+    container_name: nginx
+    hostname: nginx
+    image: nginx:1.19.5
+    ports:
+      - 80:80
+      - 443:443
+    networks:
+      - proxy
+    volumes:
+      - ./vol/nginx:/etc/nginx/conf.d
+      - ./vol/ssl:/etc/ssl
+    restart: on-failure
+
+  elasticsearch:
+    container_name: elasticsearch
+    image: elasticsearch:7.8.1
+    environment:
+      - http.host=0.0.0.0
+      - discovery.type=single-node
+      - script.allowed_types=inline
+      - thread_pool.search.queue_size=100000
+      - thread_pool.write.queue_size=10000
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
+    networks:
+      - backend
+
+  thehive:
+    container_name: thehive
+    image: thehiveproject/thehive:3.5.0-1
+    depends_on:
+      - elasticsearch
+    networks:
+      - proxy
+      - backend
+    command:
+      --cortex-port 9001
+      --cortex-key ${CORTEX_KEY}
+      --es-uri http://elasticsearch:9200
+
+  cortex:
+    container_name: cortex
+    image: thehiveproject/cortex:3.1.0-1
+    depends_on:
+      - elasticsearch
+    networks:
+      - proxy
+      - backend
+    command:
+      --job-directory ${JOB_DIRECTORY}
+    environment:
+      - 'JOB_DIRECTORY=${JOB_DIRECTORY}'
+    volumes:
+      - '/var/run/docker.sock:/var/run/docker.sock'
+      - '${JOB_DIRECTORY}:${JOB_DIRECTORY}'
+
+networks:
+  backend:
+  proxy:
+    external: true

--- a/docker/thehive35-cortex3-es7-nginx-https/vol/nginx/certs.conf
+++ b/docker/thehive35-cortex3-es7-nginx-https/vol/nginx/certs.conf
@@ -1,0 +1,2 @@
+ssl_certificate /etc/ssl/nginx-selfsigned.crt;
+ssl_certificate_key /etc/ssl/nginx-selfsigned.key;

--- a/docker/thehive35-cortex3-es7-nginx-https/vol/nginx/cortex.conf
+++ b/docker/thehive35-cortex3-es7-nginx-https/vol/nginx/cortex.conf
@@ -1,0 +1,18 @@
+server {
+  listen 443 ssl;
+  server_name cortex.yourdomain.com;
+
+  proxy_connect_timeout   600;
+  proxy_send_timeout      600;
+  proxy_read_timeout      600;
+  send_timeout            600;
+  client_max_body_size    2G;
+  proxy_buffering off;
+  client_header_buffer_size 8k;
+
+  location / {
+    add_header              Strict-Transport-Security "max-age=31536000; includeSubDomains";
+    proxy_pass            http://cortex:9001;
+    proxy_http_version      1.1;
+  }
+}

--- a/docker/thehive35-cortex3-es7-nginx-https/vol/nginx/thehive.conf
+++ b/docker/thehive35-cortex3-es7-nginx-https/vol/nginx/thehive.conf
@@ -1,0 +1,18 @@
+server {
+  listen 443 ssl;
+  server_name thehive.yourdomain.com;
+
+  proxy_connect_timeout   600;
+  proxy_send_timeout      600;
+  proxy_read_timeout      600;
+  send_timeout            600;
+  client_max_body_size    2G;
+  proxy_buffering off;
+  client_header_buffer_size 8k;
+
+  location / {
+    add_header              Strict-Transport-Security "max-age=31536000; includeSubDomains";
+    proxy_pass            http://thehive:9000;
+    proxy_http_version      1.1;
+  }
+}

--- a/docker/thehive35-cortex3-es7-nginx-https/vol/ssl/README.md
+++ b/docker/thehive35-cortex3-es7-nginx-https/vol/ssl/README.md
@@ -1,0 +1,3 @@
+# README
+
+You need to create and add your certificates into this folder and update the `certs.conf` file.


### PR DESCRIPTION
Added thehive34-cortex3-es6-nginx-https
- TheHive 3.4.4
- Cortex 3.0.1
- Elasticsearch 6.8.8
- Nginx 1.19.5

Added thehive35-cortex3-es7-nginx-https
- TheHive 3.5.0
- Cortex 3.1.0
- Elasticsearch 7.8.1
- Nginx 1.19.5