### PR TITLE
Add ScyllaDB template

### DIFF
--- a/docker/thehive4-scylladb/.gitignore
+++ b/docker/thehive4-scylladb/.gitignore
@@ -1,0 +1,3 @@
+vol/scylla/data
+vol/thehive/data
+vol/thehive/index

--- a/docker/thehive4-scylladb/docker-compose.yml
+++ b/docker/thehive4-scylladb/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.8"
+services:
+  scylladb:
+    image: scylladb/scylla
+    container_name: scylladb
+    volumes:
+      - "./vol/scylla/data:/var/lib/scylla"
+  thehive:
+    image: "thehiveproject/thehive4:latest"
+    container_name: thehive4
+    restart: unless-stopped
+    depends_on:
+      - scylladb
+    ports:
+      - "0.0.0.0:9000:9000"
+    volumes:
+      - ./vol/thehive/application.conf:/etc/thehive/application.conf
+      - ./vol/thehive/data:/opt/thp/thehive/data
+      - ./vol/thehive/index:/opt/thp/thehive/index
+    command: "--no-config --no-config-secret"

--- a/docker/thehive4-scylladb/vol/thehive/application.conf
+++ b/docker/thehive4-scylladb/vol/thehive/application.conf
@@ -1,0 +1,37 @@
+# Secret Key
+# The secret key is used to secure cryptographic functions.
+# WARNING: If you deploy your application on several servers, make sure to use the same key.
+play.http.secret.key="YouNeedToChangeThisKey"
+
+# JanusGraph
+db {
+  provider: janusgraph
+  janusgraph {
+    storage {
+      backend: cql
+      hostname: ["scylladb"]
+
+      cql {
+        cluster-name: thp       # cluster name
+        keyspace: thehive           # name of the keyspace
+        read-consistency-level: ONE
+        write-consistency-level: ONE
+      }
+    }
+
+    ## Index configuration
+    index {
+      search {
+        backend: lucene
+        directory: /opt/thp/thehive/index
+      }
+    }
+  }
+}
+
+storage {
+   provider: localfs
+   localfs.location: /opt/thp/thehive/data
+}
+
+play.http.parser.maxDiskBuffer: 50MB


### PR DESCRIPTION
This PR adds an additional docker-compose template using [Scylla](https://www.scylladb.com/) instead of Cassandra.
Scylla adds the benefit of a full CQL driver compatible distributed database with a much lower resource footprint.

As Scylla has been [tested with JanusGraph](https://www.scylladb.com/2019/05/14/powering-a-graph-data-system-with-scylla-janusgraph/) I thought to give it a shot. I started a fresh installation of thehive4 and performed various import tests and could not find any errors in the logs so far.