### PR TITLE
Add minimal configuration with HTTPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 package.json
 yarn.lock
+.DS_Store

--- a/docker/thehive4-minimal-nginx-https/docker-compose.yml
+++ b/docker/thehive4-minimal-nginx-https/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.8"
+services:
+  nginx:
+    container_name: nginx
+    hostname: nginx
+    image: nginx:1.19.5
+    ports:
+      - 443:443
+    volumes:
+      - ./vol/nginx:/etc/nginx/conf.d
+      - ./vol/ssl:/etc/ssl
+    restart: on-failure
+    links:
+      - thehive
+
+  thehive:
+    image: thehiveproject/thehive4:latest
+    environment:
+      - MAX_HEAP_SIZE=1G
+      - HEAP_NEWSIZE=1G
+    volumes:
+      - ./vol/thehive/application.conf:/etc/thehive/application.conf
+      - ./vol/thehive/db:/opt/thp/thehive/db
+      - ./vol/thehive/index:/opt/thp/thehive/index
+      - ./vol/thehive/data:/opt/thp/thehive/data
+    command: --no-config --no-config-secret

--- a/docker/thehive4-minimal-nginx-https/vol/nginx/certs.conf
+++ b/docker/thehive4-minimal-nginx-https/vol/nginx/certs.conf
@@ -1,0 +1,2 @@
+ssl_certificate /etc/ssl/nginx-selfsigned.crt;
+ssl_certificate_key /etc/ssl/nginx-selfsigned.key;

--- a/docker/thehive4-minimal-nginx-https/vol/nginx/thehive.conf
+++ b/docker/thehive4-minimal-nginx-https/vol/nginx/thehive.conf
@@ -1,0 +1,17 @@
+server {
+  listen 443 ssl;
+
+  proxy_connect_timeout   600;
+  proxy_send_timeout      600;
+  proxy_read_timeout      600;
+  send_timeout            600;
+  client_max_body_size    2G;
+  proxy_buffering off;
+  client_header_buffer_size 8k;
+
+  location / {
+    add_header              Strict-Transport-Security "max-age=31536000; includeSubDomains";
+    proxy_pass            http://thehive:9000;
+    proxy_http_version      1.1;
+  }
+}

--- a/docker/thehive4-minimal-nginx-https/vol/ssl/README.md
+++ b/docker/thehive4-minimal-nginx-https/vol/ssl/README.md
@@ -1,0 +1,3 @@
+# README
+
+You need to create and add your certificates into this folder and update the `certs.conf` file.

--- a/docker/thehive4-minimal-nginx-https/vol/thehive/application.conf
+++ b/docker/thehive4-minimal-nginx-https/vol/thehive/application.conf
@@ -1,0 +1,23 @@
+play.http.secret.key="ThehiveTestPassword"
+
+## For test only !
+db.janusgraph {
+   storage.backend: berkeleyje
+   storage.directory: /opt/thp/thehive/db
+   berkeleyje.freeDisk: 200
+
+  ## Index configuration
+  index {
+    search {
+      backend: lucene
+      directory: /opt/thp/thehive/index
+    }
+  }
+}
+
+storage {
+   provider: localfs
+   localfs.directory: /opt/thp/thehive/data
+}
+
+play.http.parser.maxDiskBuffer: 20MB


### PR DESCRIPTION
Inspired by the minimal configuration, here is a derivative that also sets up an nginx reverse proxy to allow for HTTPS.